### PR TITLE
Months fix

### DIFF
--- a/timex/timex.go
+++ b/timex/timex.go
@@ -53,6 +53,7 @@ func Diff(a, b time.Time) (year, month, day, hour, min, sec int) {
 	if month < 0 {
 		month += 12
 		year--
+		month += 12 * year
 	}
 
 	return


### PR DESCRIPTION
Hello. I'm using your library for writing black-box tests for microservices testing.
Your timex.Diff function doesn't return correct number of months so i wanted to fix this.