### PR TITLE
Update test on 32-bit architectures so it no longer fails

### DIFF
--- a/mathx/mathx_test.go
+++ b/mathx/mathx_test.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"math"
 	"testing"
+
+	"github.com/icza/gox/gox"
+	"github.com/icza/gox/osx"
 )
 
 func TestAbsInt(t *testing.T) {
@@ -14,8 +17,9 @@ func TestAbsInt(t *testing.T) {
 		{"zero", 0, 0},
 		{"pos", 1, 1},
 		{"neg", -1, 1},
-		{"minint32", math.MinInt32, -math.MinInt32},
 		{"maxint32", math.MaxInt32, math.MaxInt32},
+		// On 32-bit arch, -math.MinInt32 overflows and this test fails
+		{"minint32", math.MinInt32, gox.If(osx.Arch32bit).Int(math.MinInt32, -math.MinInt32)},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Int is a 32-bit integer on 32-bit architectures, -math.MinInt32 is one too big and causes an overflow. This causes this test to fail.

Closes #6