### PR TITLE
colorx: fix panic when ParseHexColor receives an empty string

### DIFF
--- a/imagex/colorx/colorx.go
+++ b/imagex/colorx/colorx.go
@@ -14,7 +14,7 @@ var errInvalidFormat = errors.New("invalid format")
 func ParseHexColor(s string) (c color.RGBA, err error) {
 	c.A = 0xff
 
-	if s[0] != '#' {
+	if len(s) == 0 || s[0] != '#' {
 		return c, errInvalidFormat
 	}
 

--- a/imagex/colorx/colorx_test.go
+++ b/imagex/colorx/colorx_test.go
@@ -2,6 +2,7 @@ package colorx
 
 import (
 	"fmt"
+	"testing"
 )
 
 // ExampleParseHexColor shows how to use the ParseHexColor() function.
@@ -30,4 +31,11 @@ func ExampleParseHexColor() {
 	// invalid = {  0   0   0 255}, invalid format
 	// #abcd   = {  0   0   0 255}, invalid format
 	// #-12    = {  0  17  34 255}, invalid format
+}
+
+func TestParseHexColor(t *testing.T) {
+	_, err := ParseHexColor("")
+	if err == nil {
+		t.Errorf("empty string should return error")
+	}
 }


### PR DESCRIPTION
Check if the input string has at least one byte.